### PR TITLE
Simple linear search to lookup entity times

### DIFF
--- a/csrc/piano.c
+++ b/csrc/piano.c
@@ -1,0 +1,119 @@
+#if CABAL
+#include "anemone_hash.h"
+#include "anemone_memcmp.h"
+#else
+#include "../lib/anemone/csrc/anemone_hash.h"
+#include "../lib/anemone/csrc/anemone_memcmp.h"
+#endif
+
+#include "piano.h"
+
+// NOTE: This is duplicated in Piano.Data, be sure to update
+// NOTE: it there too if you change this.
+static const uint64_t piano_seed = 0xd97ab4d1cade4055;
+
+ANEMONE_STATIC
+ANEMONE_INLINE
+uint32_t piano_hash (const uint8_t *id, size_t id_size)
+{
+    return anemone_fasthash32 (piano_seed, id, id_size);
+}
+
+ANEMONE_STATIC
+ANEMONE_INLINE
+int piano_memcmp (const uint8_t* buf0, size_t len0, const uint8_t* buf1, size_t len1)
+{
+    size_t len = len0 < len1 ? len0 : len1;
+    int cmp = anemone_memcmp (buf0, buf1, len);
+
+    if (cmp == 0) {
+        /* if buf0 is shorter, it is smaller */
+        return (int)len0 - (int)len1;
+    } else {
+        return cmp;
+    }
+}
+
+ANEMONE_STATIC
+ANEMONE_INLINE
+int piano_compare (
+    uint32_t hash0
+  , const uint8_t *id0
+  , size_t id_len0
+  , uint32_t hash1
+  , const uint8_t *id1
+  , size_t id_len1
+  )
+{
+    int hash_cmp = (int)hash0 - (int)hash1;
+
+    if (hash_cmp != 0) {
+        return hash_cmp;
+    }
+
+    return piano_memcmp (id0, id_len0, id1, id_len1);
+}
+
+ANEMONE_STATIC
+ANEMONE_INLINE
+uint8_t * piano_section32_uint8_start (piano_section32_t section, uint8_t *data)
+{
+    return data + section.offset;
+}
+
+ANEMONE_STATIC
+ANEMONE_INLINE
+int64_t * piano_section32_int64_start (piano_section32_t section, int64_t *data)
+{
+    return data + section.offset;
+}
+
+error_t piano_lookup_linear (
+    piano_t *piano
+  , const uint8_t *needle_id
+  , size_t needle_id_size
+  , int64_t *out_count
+  , const int64_t **out_times
+  )
+{
+    uint32_t needle_hash = piano_hash (needle_id, needle_id_size);
+
+    int32_t count = piano->count;
+    uint32_t *hashes = piano->hashes;
+
+    piano_section32_t *id_sections = piano->id_sections;
+    uint8_t *id_data = piano->id_data;
+
+    piano_section32_t *time_sections = piano->time_sections;
+    int64_t *time_data = piano->time_data;
+
+    for (int32_t i = 0; i < count; i++) {
+        uint32_t hash = hashes[i];
+        piano_section32_t id_section = id_sections[i];
+        piano_section32_t time_section = time_sections[i];
+
+        int cmp = piano_compare (
+            needle_hash
+          , needle_id
+          , needle_id_size
+          , hash
+          , piano_section32_uint8_start (id_section, id_data)
+          , id_section.length
+          );
+
+        if (cmp != 0)
+        {
+            continue;
+        }
+
+        *out_count = time_section.length;
+        *out_times = piano_section32_int64_start (time_section, time_data);
+
+        return 0;
+    }
+
+    *out_count = 0;
+    *out_times = NULL;
+
+    return 0;
+}

--- a/csrc/piano.h
+++ b/csrc/piano.h
@@ -1,0 +1,29 @@
+#if CABAL
+#include "anemone_base.h"
+#else
+#include "../lib/anemone/csrc/anemone_base.h"
+#endif
+
+typedef struct piano_section32 {
+    int32_t offset;
+    int32_t length;
+} piano_section32_t;
+
+typedef struct piano {
+    int32_t count;
+    uint32_t *hashes;
+
+    piano_section32_t *id_sections;
+    uint8_t *id_data;
+
+    piano_section32_t *time_sections;
+    int64_t *time_data;
+} piano_t;
+
+error_t piano_lookup_linear (
+    piano_t *piano
+  , const uint8_t *entity_id
+  , size_t entity_id_size
+  , int64_t *out_count
+  , const int64_t **out_times
+  );

--- a/csrc/piano_bindings.h
+++ b/csrc/piano_bindings.h
@@ -1,0 +1,6 @@
+#if __clang__
+  #pragma clang diagnostic ignored "-Wformat"
+  #pragma clang diagnostic ignored "-Wunused-variable"
+#elif __GNUC__
+  #pragma GCC diagnostic ignored "-Wformat"
+#endif

--- a/piano.cabal
+++ b/piano.cabal
@@ -10,6 +10,10 @@ cabal-version:         >= 1.8
 build-type:            Custom
 description:           piano
 
+extra-source-files:
+                    csrc/*.h
+                    csrc/*.c
+
 library
   build-depends:
                       base                            >= 3          && < 5
@@ -17,11 +21,14 @@ library
                     , ambiata-p
                     , ambiata-x-show
                     , ambiata-x-vector
+                    , bindings-DSL                    >= 1.0.0      && <= 1.0.23
                     , bytestring                      == 0.10.*
+                    , containers                      == 0.5.*
                     , text                            == 1.2.*
                     , thyme                           == 0.3.*
                     , transformers                    >= 0.3        && < 0.6
                     , vector                          == 0.11.*
+                    , vector-algorithms               == 0.7.*
 
   ghc-options:
                     -Wall -O2
@@ -32,7 +39,25 @@ library
   exposed-modules:
                     Piano
                     Piano.Data
+                    Piano.Foreign
+                    Piano.Foreign.Bindings
                     Piano.Parser
+
+  include-dirs:
+                    csrc
+
+  install-includes:
+                    piano.h
+
+  includes:
+                    piano.h
+                    piano_bindings.h
+
+  c-sources:
+                    csrc/piano.c
+
+  cc-options:
+                    -std=c99 -O3 -msse4.2 -Wall -Werror -DCABAL=1
 
 executable piano
   ghc-options:
@@ -53,8 +78,9 @@ executable piano
                     , bytestring                      == 0.10.*
                     , optparse-applicative            >= 0.11 && < 0.13
                     , text
+                    , thyme                           == 0.3.*
                     , transformers                    >= 0.3        && < 0.6
-
+                    , vector                          == 0.11.*
 
 test-suite test
   type:
@@ -74,9 +100,11 @@ test-suite test
                     , ambiata-piano
                     , ambiata-disorder-core
                     , ambiata-disorder-corpus
+                    , ambiata-disorder-eithert
                     , ambiata-disorder-jack
                     , ambiata-p
                     , bytestring                      == 0.10.*
+                    , containers                      == 0.5.*
                     , QuickCheck                      >= 2.8.2 && < 2.9
                     , quickcheck-instances            == 0.3.*
                     , thyme                           == 0.3.*

--- a/src/Piano/Data.hs
+++ b/src/Piano/Data.hs
@@ -2,25 +2,151 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
 module Piano.Data (
-    Key(..)
+    Entity
+  , mkEntity
+  , unsafeMkEntity
+  , entityHash
+  , entityId
+
+  , Key(..)
+  , sortKeys
+  , sortUnboxedKeys
+
+  , toIvorySeconds
+  , fromIvorySeconds
+  , ivoryEpoch
   ) where
 
-import           Data.ByteString (ByteString)
-import           Data.Thyme (Day)
+import           Anemone.Foreign.Hash (fasthash32')
+
+import qualified Data.ByteString as B
+import           Data.ByteString.Internal (ByteString(..))
+import           Data.Thyme (Day(..))
+import           Data.Thyme.Time (addDays, diffDays)
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Algorithms.AmericanFlag as American
+import qualified Data.Vector.Unboxed as Unboxed
+import           Data.Word (Word8, Word32)
 
 import           GHC.Generics (Generic)
 
+import           Foreign.ForeignPtr (ForeignPtr)
+
 import           P
+
+import qualified Prelude as Savage
+
+import           System.IO.Unsafe (unsafePerformIO)
 
 import           X.Text.Show (gshowsPrec)
 
+data Entity =
+  Entity {
+      entityHash :: !Word32
+    , entityId :: !ByteString
+    } deriving (Eq, Ord, Generic)
 
 data Key =
   Key {
-      keyEntity :: !ByteString
+      keyEntity :: !Entity
     , keyTime :: !Day
     } deriving (Eq, Ord, Generic)
+
+instance American.Lexicographic Key where
+  terminate (Key (Entity _ bs) _) n =
+    -- Unforunately we can't write this in terms of the other instances, so we
+    -- have to cheat and inline their implementations:
+    --
+    --   n >= sizeof(entity hash) + sizeof(entity id) + sizeof(day)
+    --
+    n >= 4 + B.length bs + 8
+  {-# INLINE terminate #-}
+
+  size _ =
+    American.size (Savage.undefined :: Word32) `max`
+    American.size (Savage.undefined :: ByteString) `max`
+    American.size (Savage.undefined :: Int)
+  {-# INLINE size #-}
+
+  index i (Key (Entity h e) t) =
+    if i < 4 then
+      American.index i h
+    else if i < 4 + B.length e then
+      American.index (i - 4) e
+    else
+      American.index (i - 4 - B.length e) (toModifiedJulianDay t)
+  {-# INLINE index #-}
+
+instance Show Entity where
+  showsPrec =
+    gshowsPrec
 
 instance Show Key where
   showsPrec =
     gshowsPrec
+
+sortKeys :: Boxed.Vector Key -> Boxed.Vector Key
+sortKeys keys =
+  unsafePerformIO $ do
+    mkeys <- Boxed.thaw keys
+    American.sort mkeys
+    Boxed.unsafeFreeze mkeys
+
+sortUnboxedKeys ::
+  ForeignPtr Word8 ->
+  Unboxed.Vector (Word32, Int, Int, Day) ->
+  Unboxed.Vector (Word32, Int, Int, Day)
+sortUnboxedKeys fp keys =
+  unsafePerformIO $ do
+    mkeys <- Unboxed.thaw keys
+
+    let
+      cmp (hash0, off0, len0, day0) (hash1, off1, len1, day1) =
+        compare
+          (Key (Entity hash0 (PS fp off0 len0)) day0)
+          (Key (Entity hash1 (PS fp off1 len1)) day1)
+
+      terminate (hash, off, len, day) n =
+        American.terminate (Key (Entity hash (PS fp off len)) day) n
+
+      size =
+        American.size (Key (Entity 0 B.empty) ivoryEpoch)
+
+      index i (hash, off, len, day) =
+        American.index i (Key (Entity hash (PS fp off len)) day)
+
+    American.sortBy cmp terminate size index mkeys
+
+    Unboxed.unsafeFreeze mkeys
+
+mkEntity :: ByteString -> Entity
+mkEntity bs =
+  Entity (hashEntity bs) bs
+{-# INLINE mkEntity #-}
+
+unsafeMkEntity :: Word32 -> ByteString -> Entity
+unsafeMkEntity =
+  Entity
+{-# INLINE unsafeMkEntity #-}
+
+hashEntity :: ByteString -> Word32
+hashEntity =
+  -- NOTE: This is duplicated in piano.c, be sure to update
+  -- NOTE: it there too if you change this.
+  fasthash32' 0xd97ab4d1cade4055
+{-# INLINE hashEntity #-}
+
+toIvorySeconds :: Day -> Int64
+toIvorySeconds day =
+  fromIntegral $ (diffDays day ivoryEpoch) * 86400
+{-# INLINE toIvorySeconds #-}
+
+fromIvorySeconds :: Int64 -> Day
+fromIvorySeconds time =
+  addDays (fromIntegral time `div` 86400) ivoryEpoch
+{-# INLINE fromIvorySeconds #-}
+
+ivoryEpoch :: Day
+ivoryEpoch =
+  ModifiedJulianDay (-94493) -- 1600-03-01
+{-# INLINE ivoryEpoch #-}

--- a/src/Piano/Foreign.hs
+++ b/src/Piano/Foreign.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Piano.Foreign (
+    Piano(..)
+  , newPiano
+  , lookupLinear
+  ) where
+
+import qualified Data.ByteString as B
+import           Data.ByteString.Internal (ByteString(..))
+import qualified Data.ByteString.Internal as B
+import qualified Data.List as List
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Thyme (Day(..))
+import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Unboxed as Unboxed
+import           Data.Word (Word8)
+
+import           Foreign.Concurrent (newForeignPtr)
+import           Foreign.ForeignPtr (ForeignPtr, newForeignPtr_, withForeignPtr)
+import           Foreign.Marshal (alloca, malloc, mallocBytes, newArray, free)
+import           Foreign.Ptr (Ptr, plusPtr)
+import           Foreign.Storable (peek, poke)
+
+import           P
+
+import           Piano.Data
+import           Piano.Foreign.Bindings
+
+import           System.IO (IO)
+
+
+newtype Piano =
+  Piano {
+      unPiano :: ForeignPtr C'piano
+    }
+
+allocIdSections :: [ByteString] -> IO (Ptr C'piano_section32)
+allocIdSections bss =
+  let
+    lengths =
+      fmap (fromIntegral . B.length) bss
+
+    offsets =
+      List.scanl' (+) 0 lengths
+  in
+    newArray $ List.zipWith C'piano_section32 offsets lengths
+
+allocIdData :: [ByteString] -> IO (Ptr Word8)
+allocIdData bss = do
+  let
+    PS fp off len =
+      B.concat bss
+
+  dst <- mallocBytes len
+
+  withForeignPtr fp $ \src ->
+    B.memcpy (dst `plusPtr` off) src len
+
+  pure dst
+
+allocTimeSections :: [Set a] -> IO (Ptr C'piano_section32)
+allocTimeSections tss =
+  let
+    lengths =
+      fmap (fromIntegral . Set.size) tss
+
+    offsets =
+      List.scanl' (+) 0 lengths
+  in
+    newArray $ List.zipWith C'piano_section32 offsets lengths
+
+allocTimeData :: [Set Int64] -> IO (Ptr Int64)
+allocTimeData =
+  newArray . concatMap Set.toList
+
+allocPiano :: Map Entity (Set Day) -> IO (Ptr C'piano)
+allocPiano entities = do
+  pPiano <- malloc
+  pHashes <- newArray . fmap entityHash $ Map.keys entities
+  pIdSections <- allocIdSections . fmap entityId $ Map.keys entities
+  pIdData <- allocIdData . fmap entityId $ Map.keys entities
+  pTimeSections <- allocTimeSections $ Map.elems entities
+  pTimeData <- allocTimeData . fmap (Set.mapMonotonic toIvorySeconds) $ Map.elems entities
+
+  poke pPiano C'piano {
+      c'piano'count = fromIntegral (Map.size entities)
+    , c'piano'hashes = pHashes
+    , c'piano'id_sections = pIdSections
+    , c'piano'id_data = pIdData
+    , c'piano'time_sections = pTimeSections
+    , c'piano'time_data = pTimeData
+    }
+
+  pure pPiano
+
+freePiano :: Ptr C'piano -> IO ()
+freePiano pPiano = do
+  piano <- peek pPiano
+  free pPiano
+
+  free $ c'piano'hashes piano
+  free $ c'piano'id_sections piano
+  free $ c'piano'id_data piano
+  free $ c'piano'time_sections piano
+  free $ c'piano'time_data piano
+
+newPiano :: Map Entity (Set Day) -> IO Piano
+newPiano keys = do
+  ptr <- allocPiano keys
+  Piano <$> newForeignPtr ptr (freePiano ptr)
+
+lookupLinear :: Piano -> ByteString -> IO (Maybe (Unboxed.Vector Day))
+lookupLinear (Piano pfp) (PS nfp noff nlen) =
+  withForeignPtr pfp $ \pptr ->
+  withForeignPtr nfp $ \nptr ->
+  alloca $ \pcount ->
+  alloca $ \pptimes -> do
+    err <- c'piano_lookup_linear pptr (nptr `plusPtr` noff) (fromIntegral nlen) pcount pptimes
+
+    time_count <- fromIntegral <$> peek pcount
+
+    if err == 0 && time_count /= 0 then do
+      ptimes <- peek pptimes
+      fptimes <- newForeignPtr_ ptimes
+
+      let
+        -- force the evaluation as 'ptimes' won't exist when we return
+        !times =
+          Unboxed.map fromIvorySeconds .
+          Unboxed.convert $
+          Storable.unsafeFromForeignPtr0 fptimes time_count
+
+      pure $ Just times
+    else
+      pure Nothing

--- a/src/Piano/Foreign/Bindings.hsc
+++ b/src/Piano/Foreign/Bindings.hsc
@@ -1,0 +1,34 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+module Piano.Foreign.Bindings where
+
+import Anemone.Foreign.Data (CError(..))
+
+--
+-- This module contains 1:1 bindings for all the zebra header files, in the
+-- style of bindings-DSL, for "nice" wrappers, see the Piano.Foreign module.
+--
+
+#include <bindings.dsl.h>
+#include "piano_bindings.h"
+#include "piano.h"
+
+#strict_import
+
+#starttype struct piano_section32
+#field offset , Int32
+#field length , Int32
+#stoptype
+
+#starttype struct piano
+#field count , Int32
+#field hashes , Ptr Word32
+#field id_sections , Ptr <piano_section32>
+#field id_data , Ptr Word8
+#field time_sections , Ptr <piano_section32>
+#field time_data , Ptr Int64
+#stoptype
+
+#ccall piano_lookup_linear , Ptr <piano> -> Ptr Word8 -> CSize -> Ptr Int64 -> Ptr (Ptr Int64) -> IO CError

--- a/test/Test/Piano/Data.hs
+++ b/test/Test/Piano/Data.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Piano.Data where
+
+import           Disorder.Core.Run (ExpectedTestSpeed(..), disorderCheckEnvAll)
+import           Disorder.Jack
+
+import qualified Data.ByteString as B
+import           Data.ByteString.Internal (ByteString(..))
+import qualified Data.List as List
+import           Data.Thyme (Day)
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Unboxed as Unboxed
+import           Data.Word (Word8, Word32)
+
+import           Foreign.ForeignPtr (ForeignPtr)
+
+import           P
+
+import           Piano.Data
+
+import           System.IO (IO)
+
+import           Test.Piano.Jack
+
+
+fromUnboxedKeys :: ForeignPtr Word8 -> Unboxed.Vector (Word32, Int, Int, Day) -> [Key]
+fromUnboxedKeys fp keys =
+  let
+    fromUnboxed (hash, off, len, time) =
+      Key (unsafeMkEntity hash $ PS fp off len) time
+  in
+    fmap fromUnboxed $
+    Unboxed.toList keys
+
+toUnboxedKeys :: [Key] -> (ForeignPtr Word8, Unboxed.Vector (Word32, Int, Int, Day))
+toUnboxedKeys keys =
+  let
+    PS fp off _ =
+      B.concat $
+      fmap (entityId . keyEntity) keys
+
+    lengths =
+      fmap (fromIntegral . B.length) $
+      fmap (entityId . keyEntity) keys
+
+    offsets =
+      List.scanl' (+) off lengths
+
+    hashes =
+      fmap (entityHash . keyEntity) keys
+
+    times =
+      fmap keyTime keys
+  in
+    (fp, Unboxed.fromList $ List.zip4 hashes offsets lengths times)
+
+prop_sort_keys :: Property
+prop_sort_keys =
+  gamble (listOf jKey) $ \keys ->
+    List.sort keys
+    ===
+    Boxed.toList (sortKeys (Boxed.fromList keys))
+
+prop_sort_unboxed_keys :: Property
+prop_sort_unboxed_keys =
+  gamble (listOf jKey) $ \keys ->
+    List.sort keys
+    ===
+    let
+      (fp, ukeys) =
+        toUnboxedKeys keys
+    in
+      fromUnboxedKeys fp (sortUnboxedKeys fp ukeys)
+
+return []
+tests :: IO Bool
+tests =
+  $disorderCheckEnvAll TestRunMore

--- a/test/Test/Piano/Foreign.hs
+++ b/test/Test/Piano/Foreign.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Piano.Foreign where
+
+import           Disorder.Core.IO (testIO)
+import           Disorder.Core.Run (ExpectedTestSpeed(..), disorderCheckEnvAll)
+import           Disorder.Jack
+
+import qualified Data.Vector.Unboxed as Unboxed
+
+import           P
+
+import           Piano.Data
+import           Piano.Foreign
+
+import           System.IO (IO)
+
+import           Test.Piano.Jack
+
+
+prop_lookup_linear :: Property
+prop_lookup_linear =
+  gamble jKey $ \k0@(Key e t) ->
+  gamble (listOf jKey) $ \ks0 ->
+  testIO $ do
+    let
+      keys =
+        fromKeys (k0 : ks0)
+
+    piano <- newPiano keys
+    mts <- lookupLinear piano $ entityId e
+
+    case mts of
+      Nothing ->
+        pure .
+          counterexample ("Entity not found: " <> show e) $
+          False
+      Just ts ->
+        pure .
+          counterexample ("Found entity: " <> show (e, ts)) $
+          counterexample ("Time was missing: " <> show t) $
+          Unboxed.elem t ts
+
+return []
+tests :: IO Bool
+tests =
+  $disorderCheckEnvAll TestRunMore

--- a/test/Test/Piano/Jack.hs
+++ b/test/Test/Piano/Jack.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Piano.Jack where
+
+import           Disorder.Corpus (muppets)
+import           Disorder.Jack
+
+import qualified Data.ByteString as B
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Thyme (Day)
+import           Data.Thyme.Time (fromGregorian)
+import           Data.Word (Word8)
+
+import           P
+
+import           Piano.Data
+
+
+jKey :: Jack Key
+jKey =
+  Key
+    <$> jEntity
+    <*> jTime
+
+jEntity :: Jack Entity
+jEntity =
+  fmap mkEntity $
+  oneOf [
+      elements muppets
+    , B.pack <$> listOf jEntityChar
+    ]
+
+jEntityChar :: Jack Word8
+jEntityChar =
+  arbitrary `suchThat` \b ->
+    b /= pipe &&
+    b /= feed
+
+feed :: Word8
+feed =
+  0x0A -- '\n'
+
+pipe :: Word8
+pipe =
+  0x7C -- '|'
+
+jTime :: Jack Day
+jTime =
+  fromGregorian
+    <$> choose (1600, 3000)
+    <*> choose (1, 12)
+    <*> choose (1, 31)
+
+fromKey :: Key -> (Entity, Set Day)
+fromKey (Key e t) =
+  (e, Set.singleton t)
+
+fromKeys :: [Key] -> Map Entity (Set Day)
+fromKeys =
+  Map.fromListWith Set.union . fmap fromKey 
+
+toKeys :: Map Entity (Set Day) -> [Key]
+toKeys =
+  concatMap (\(e, ts) -> fmap (Key e) $ Set.toList ts) .
+  Map.toList

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,9 +1,13 @@
 import           Disorder.Core.Main
 
+import qualified Test.Piano.Data
+import qualified Test.Piano.Foreign
 import qualified Test.Piano.Parser
 
 main :: IO ()
 main =
   disorderMain [
-      Test.Piano.Parser.tests
+      Test.Piano.Data.tests
+    , Test.Piano.Foreign.tests
+    , Test.Piano.Parser.tests
     ]


### PR DESCRIPTION
This adds a stupid / simple linear search to lookup entity times.

This forces out most of the FFI infrastructure we need for a fancier lookup and gives us a baseline to compare to.

! @amosr @tranma

On top of https://github.com/ambiata/piano/pull/3