### PR TITLE
Add benchmark vs Data.Map

### DIFF
--- a/bench/piano-bench.hs
+++ b/bench/piano-bench.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Data.ByteString.Char8 as Char8
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Thyme (Day(..))
+
+import           Criterion.Main (Benchmark, env, bgroup, bench, nf, nfIO)
+import           Criterion.Main (defaultMainWith, defaultConfig)
+import           Criterion.Types (Config(..))
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           Piano.Data
+import           Piano.Foreign
+
+import           System.IO (IO)
+
+import           Text.Printf (printf)
+
+
+main :: IO ()
+main =
+  defaultMainWith config [
+      benchmark
+    ]
+
+config :: Config
+config =
+  defaultConfig {
+      reportFile =
+        Just "dist/build/piano-bench.html"
+    , csvFile =
+        Just "dist/build/piano-bench.csv"
+    }
+
+data Env =
+  Env {
+      envMap :: !(Map Entity (Set Day))
+    , envPiano :: !Piano
+    } deriving (Generic)
+
+instance NFData Env
+
+mkEnv :: IO Env
+mkEnv = do
+  let
+    mkKey n =
+      (entity n, Set.singleton $ ModifiedJulianDay 0)
+
+    entities =
+      Map.fromAscList $
+      fmap mkKey [0..entityCount - 1]
+
+  Env entities <$> newPiano entities
+
+entityCount :: Int
+entityCount =
+  1000000
+
+entity :: Int -> Entity
+entity =
+  mkEntity . Char8.pack . printf "SAVAGE+%040d"
+
+benchmark :: Benchmark
+benchmark =
+  env mkEnv $ \ ~x ->
+  let
+    !needle =
+      entity $ entityCount - 1
+  in
+    bgroup "lookup" [
+        bench "Data.Map" $ nf (Map.lookup needle . envMap) x
+      , bench "linear" $ nfIO (lookupLinear (envPiano x) (entityId needle))
+      ]

--- a/piano.cabal
+++ b/piano.cabal
@@ -82,6 +82,29 @@ executable piano
                     , transformers                    >= 0.3        && < 0.6
                     , vector                          == 0.11.*
 
+benchmark piano-bench
+  type:
+                    exitcode-stdio-1.0
+
+  main-is:
+                    piano-bench.hs
+
+  ghc-options:
+                    -Wall -threaded -O2
+
+  hs-source-dirs:
+                    bench
+
+  build-depends:
+                      base                            >= 3          && < 5
+                    , ambiata-piano
+                    , ambiata-p
+                    , bytestring                      == 0.10.*
+                    , containers                      == 0.5.*
+                    , criterion                       == 1.1.*
+                    , thyme                           == 0.3.*
+                    , vector                          == 0.11.*
+
 test-suite test
   type:
                     exitcode-stdio-1.0

--- a/src/Piano/Data.hs
+++ b/src/Piano/Data.hs
@@ -85,6 +85,10 @@ instance Show Key where
   showsPrec =
     gshowsPrec
 
+instance NFData Entity
+
+instance NFData Key
+
 sortKeys :: Boxed.Vector Key -> Boxed.Vector Key
 sortKeys keys =
   unsafePerformIO $ do

--- a/src/Piano/Foreign.hs
+++ b/src/Piano/Foreign.hs
@@ -39,6 +39,10 @@ newtype Piano =
       unPiano :: ForeignPtr C'piano
     }
 
+instance NFData Piano where
+  rnf !_ =
+    ()
+
 allocIdSections :: [ByteString] -> IO (Ptr C'piano_section32)
 allocIdSections bss =
   let


### PR DESCRIPTION
Added some silly benchmarks, will add the fast lookup next.

Here is linear scan on 1 million entities vs Data.Map:

<img width="917" src="https://cloud.githubusercontent.com/assets/134805/21088064/02b92bfe-c080-11e6-8ba0-a66fda1fdb5e.png">

! @amosr @tranma 