### PR TITLE
Add support for labeled chord times

### DIFF
--- a/bench/piano-bench.hs
+++ b/bench/piano-bench.hs
@@ -53,7 +53,7 @@ mkEnv = do
       EndTime 0
 
     mkKey n =
-      (entity n, Set.singleton time)
+      (entity n, Set.singleton (Label time . Char8.pack $ show time))
 
     piano =
       Piano time time 1 .

--- a/csrc/piano.h
+++ b/csrc/piano.h
@@ -40,9 +40,9 @@ int64_t piano_max_count (
 //
 // Lookup an entity in the chord descriptor.
 //
-// If the entity is found, its array of chord times are returned, sorted oldest
-// to newest. The times returned are an exclusive bound on the scope of the
-// chord query for the entity requested.
+// If the entity is found, its array of labeled chord times are returned,
+// sorted oldest to newest. The times returned are an exclusive bound on the
+// scope of the chord query for the entity requested.
 //
 // Times are in seconds since 1600-03-01 (ivory epoch).
 //
@@ -53,7 +53,10 @@ error_t piano_lookup (
   , const uint8_t *needle_id
   , size_t needle_id_size
   , int64_t *out_count
-  , const int64_t **out_times
+  , const int64_t **out_label_times
+  , const int64_t **out_label_name_offsets
+  , const int64_t **out_label_name_lengths
+  , const uint8_t **out_label_name_data
   );
 
 #endif//__PIANO_H

--- a/csrc/piano_internal.h
+++ b/csrc/piano_internal.h
@@ -21,8 +21,11 @@ struct piano {
     piano_section32_t *id_sections;
     uint8_t *id_data;
 
-    piano_section32_t *time_sections;
-    int64_t *time_data;
+    piano_section32_t *label_sections;
+    int64_t *label_time_data;
+    int64_t *label_name_offsets;
+    int64_t *label_name_lengths;
+    uint8_t *label_name_data;
 };
 
 error_t piano_lookup_binary (
@@ -30,7 +33,10 @@ error_t piano_lookup_binary (
   , const uint8_t *entity_id
   , size_t entity_id_size
   , int64_t *out_count
-  , const int64_t **out_times
+  , const int64_t **out_label_times
+  , const int64_t **out_label_name_offsets
+  , const int64_t **out_label_name_lengths
+  , const uint8_t **out_label_name_data
   );
 
 #endif//__PIANO_INTERNAL_H

--- a/main/piano.hs
+++ b/main/piano.hs
@@ -10,7 +10,7 @@ import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy.Char8 as Lazy
-import qualified Data.Vector.Unboxed as Unboxed
+import qualified Data.Vector as Boxed
 
 import           P
 
@@ -102,4 +102,4 @@ run = \case
         Nothing ->
           putStrLn "<not found>"
         Just endTimes ->
-          Char8.putStrLn . Char8.intercalate "|" . fmap (renderDate . fromExclusive) $ Unboxed.toList endTimes
+          Char8.putStrLn . Char8.intercalate "|" . fmap (renderDate . fromExclusive . labelTime) $ Boxed.toList endTimes

--- a/src/Piano/Foreign/Bindings.hsc
+++ b/src/Piano/Foreign/Bindings.hsc
@@ -32,12 +32,15 @@ import Anemone.Foreign.Data (CError(..))
 #field hashes , Ptr Word32
 #field id_sections , Ptr <piano_section32>
 #field id_data , Ptr Word8
-#field time_sections , Ptr <piano_section32>
-#field time_data , Ptr Int64
+#field label_sections, Ptr <piano_section32>
+#field label_time_data , Ptr Int64
+#field label_name_offsets , Ptr Int64
+#field label_name_lengths , Ptr Int64
+#field label_name_data , Ptr Word8
 #stoptype
 
 #ccall_unsafe piano_min_time , Ptr <piano> -> IO Int64
 #ccall_unsafe piano_max_time , Ptr <piano> -> IO Int64
 #ccall_unsafe piano_max_count , Ptr <piano> -> IO Int64
-#ccall_unsafe piano_lookup , Ptr <piano> -> Ptr Word8 -> CSize -> Ptr Int64 -> Ptr (Ptr Int64) -> IO CError
-#ccall_unsafe piano_lookup_binary , Ptr <piano> -> Ptr Word8 -> CSize -> Ptr Int64 -> Ptr (Ptr Int64) -> IO CError
+#ccall_unsafe piano_lookup , Ptr <piano> -> Ptr Word8 -> CSize -> Ptr Int64 -> Ptr (Ptr Int64) -> Ptr (Ptr Int64) -> Ptr (Ptr Int64) -> Ptr (Ptr Word8) -> IO CError
+#ccall_unsafe piano_lookup_binary , Ptr <piano> -> Ptr Word8 -> CSize -> Ptr Int64 -> Ptr (Ptr Int64) -> Ptr (Ptr Int64) -> Ptr (Ptr Int64) -> Ptr (Ptr Word8) -> IO CError

--- a/test/Test/Piano/Jack.hs
+++ b/test/Test/Piano/Jack.hs
@@ -3,43 +3,52 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Piano.Jack where
 
-import           Disorder.Corpus (muppets)
+import           Disorder.Corpus (muppets, boats)
 import           Disorder.Jack
 
-import qualified Data.ByteString as B
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as Char8
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import           Data.Thyme.Time (fromGregorian)
+import           Data.Thyme.Time (fromGregorian, toGregorian)
 import           Data.Word (Word8)
 
 import           P
 
 import           Piano.Data
 
+import           Text.Printf (printf)
+
 
 jKey :: Jack Key
 jKey =
   Key
     <$> jEntity
-    <*> jEndTime
+    <*> jLabel
+
+jDateKey :: Jack Key
+jDateKey =
+  Key
+    <$> jEntity
+    <*> jDateLabel
 
 jEntity :: Jack Entity
 jEntity =
   fmap mkEntity $
   oneOf [
       elements muppets
-    , B.pack <$> listOf jEntityChar
+    , ByteString.pack <$> listOf jNameChar
     ]
 
-jEntityChar :: Jack Word8
-jEntityChar =
+jNameChar :: Jack Word8
+jNameChar =
   arbitrary `suchThat` \b ->
     b /= pipe &&
     b /= feed
 
 jPiano :: Jack Piano
 jPiano =
-  fromKeys <$> listOf1 jKey
+  fromKeys <$> listOf1 jDateKey
 
 feed :: Word8
 feed =
@@ -48,6 +57,19 @@ feed =
 pipe :: Word8
 pipe =
   0x7C -- '|'
+
+jLabel :: Jack Label
+jLabel =
+  Label
+    <$> jEndTime
+    <*> oneOf [elements boats, ByteString.pack <$> listOf jNameChar]
+
+jDateLabel :: Jack Label
+jDateLabel = do
+  time <- jEndTime
+  case toGregorian $ fromExclusive time of
+    (y, m, d) ->
+      pure $ Label time (Char8.pack $ printf "%04d-%02d-%02d" y m d)
 
 jEndTime :: Jack EndTime
 jEndTime =

--- a/test/Test/Piano/Parser.hs
+++ b/test/Test/Piano/Parser.hs
@@ -23,8 +23,8 @@ import           Test.Piano.Jack
 
 prop_parse_keys_valid_map :: Property
 prop_parse_keys_valid_map =
-  gamble jKey $ \k0@(Key e t) ->
-  gamble (listOf jKey) $ \ks0 ->
+  gamble jDateKey $ \k0@(Key e t) ->
+  gamble (listOf jDateKey) $ \ks0 ->
     testEither renderParserError $ do
       let
         keys0 =
@@ -34,7 +34,7 @@ prop_parse_keys_valid_map =
           fromKeys keys0
 
       Piano minTime maxTime maxCount ks <-
-        parsePiano . renderKeys $ toList keys0
+        parsePiano . renderInclusiveKeys $ toList keys0
 
       pure $ conjoin [
           counterexample "Minimum time was incorrect" $
@@ -58,13 +58,13 @@ prop_parse_keys_valid_map =
 
 prop_tripping_keys :: Property
 prop_tripping_keys =
-  gamble (fromKeys <$> listOf1 jKey) $
-    tripping (renderKeys . toKeys) parsePiano
+  gamble (fromKeys <$> listOf1 jDateKey) $
+    tripping (renderInclusiveKeys . toKeys) parsePiano
 
 prop_tripping_key :: Property
 prop_tripping_key =
-  gamble jKey $
-    tripping renderKey parseKey
+  gamble jDateKey $
+    tripping renderInclusiveKey parseKey
 
 prop_tripping_date :: Property
 prop_tripping_date =


### PR DESCRIPTION
This keeps the original date string around so that it can be placed in the output of a chord.

In the longer term we will add support for parsing chord descriptors which have identifiers for labels, but this not necessary right now.

! @tranma 